### PR TITLE
feat: Unique package name

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.reactnativegpaybutton">
 
 </manifest>
   

--- a/android/src/main/java/com/reactnativegpaybutton/RNGooglePayButtonImageManager.java
+++ b/android/src/main/java/com/reactnativegpaybutton/RNGooglePayButtonImageManager.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.reactnativegpaybutton;
 
 import android.view.LayoutInflater;
 import android.view.View;

--- a/android/src/main/java/com/reactnativegpaybutton/RNGooglePayButtonPackage.java
+++ b/android/src/main/java/com/reactnativegpaybutton/RNGooglePayButtonPackage.java
@@ -1,5 +1,5 @@
 
-package com.reactlibrary;
+package com.reactnativegpaybutton;
 
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Having conflicting package names results in a build failure in RN. Since `com.reactlibrary` is the default package name, it ends up being that any other package with the same default name causes build failures if this and that package are both pulled into a project.

This resolves it by naming it something unique (the repository name itself). Note that it's only one level deep - feel free to extend it if you like, I only changed the suffix to get our builds going with reasonable uniqueness on the package name.